### PR TITLE
Fix typo & extend docstring

### DIFF
--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -94,12 +94,13 @@ If no REMOTE-FILENAME is given, the LOCAL-FILENAME is used."
 
 ;;;###autoload
 (defun transfer-sh-upload (async)
-  "Uploads either active region of complete buffer to transfer.sh.
+  "Uploads either active region or complete buffer to transfer.sh.
 
 If a region is active, that region is exported to a file and then
 uploaded, otherwise the complete buffer is uploaded.  The remote
-file name is determined by customize-variables and the buffer
-name."
+file name is determined by the custom variables
+`transfer-sh-remote-prefix' and `transfer-sh-remote-suffix', and
+the buffer name."
   (interactive "P")
   (let* ((remote-filename (concat transfer-sh-remote-prefix (buffer-name) transfer-sh-remote-suffix))
          (local-filename (if (use-region-p)


### PR DESCRIPTION
Just a small fix I noticed when looking at https://github.com/Brillow/transfer-sh.el/pull/2.
