### PR TITLE
Flexibility to choose an upload agent

### DIFF
--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -74,22 +74,20 @@
   :group 'transfer-sh)
 
 ;;;###autoload
-(defun transfer-sh-upload-file-async (local-filename &optional remote-filename)
+(defun transfer-sh-upload-file-async (local-filename)
   "Uploads file LOCAL-FILENAME to transfer.sh in background.
 
-If no REMOTE-FILENAME is given, the LOCAL-FILENAME is used."
+Read from minibuffer the remote file name visible in the transfer.sh link and run `transfer-sh-run-upload-agent'."
   (interactive "ffile: ")
-  (async-start
-   `(lambda ()
-      ,(async-inject-variables "local-filename")
-      ,(async-inject-variables "remote-filename")
-      (shell-command-to-string
-        (concat "curl --silent --upload-file "
-                (shell-quote-argument local-filename)
-                " " (shell-quote-argument (concat "https://transfer.sh/" remote-filename)))))
-   `(lambda (transfer-link)
-      (kill-new transfer-link)
-      (message transfer-link))))
+  (let* ((remote-filename (read-from-minibuffer
+			   (format "Remote filename (default %s): "
+				   (file-name-nondirectory local-filename))
+			   (file-name-nondirectory local-filename))))
+    (async-start
+     `(lambda ()
+	,(async-inject-variables "local-filename")
+	,(async-inject-variables "remote-filename")
+	,(transfer-sh-run-upload-agent local-filename remote-filename)))))
 
 ;;;###autoload
 (defun transfer-sh-upload-file (local-filename)

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -78,9 +78,10 @@
 (defun transfer-sh-upload-file-async (local-filename &optional remote-filename)
   "Upload file LOCAL-FILENAME to transfer.sh in background.
 
-If no REMOTE-FILENAME is provided, read from minibuffer the
-remote file name visible in the transfer.sh link and run
-`transfer-sh-run-upload-agent'."
+REMOTE-FILENAME is the name used in the transfer.sh link. If not
+provided, query the user.
+
+This function uses `transfer-sh-run-upload-agent'."
   (interactive "ffile: ")
   (or remote-filename
       (setq remote-filename (read-from-minibuffer
@@ -97,9 +98,10 @@ remote file name visible in the transfer.sh link and run
 (defun transfer-sh-upload-file (local-filename &optional remote-filename)
   "Uploads file LOCAL-FILENAME to transfer.sh.
 
-If no REMOTE-FILENAME is provided, read from minibuffer the
-remote file name visible in the transfer.sh link and run
-`transfer-sh-run-upload-agent'."
+REMOTE-FILENAME is the name used in the transfer.sh link. If not
+provided, query the user.
+
+This function uses `transfer-sh-run-upload-agent'."
   (interactive "ffile: ")
   (transfer-sh-run-upload-agent
    local-filename
@@ -110,7 +112,7 @@ remote file name visible in the transfer.sh link and run
         (file-name-nondirectory local-filename)))))
 
 (defun transfer-sh-run-upload-agent (local-filename  &optional remote-filename)
-  "Uploads LOCAL-FILENAME to transfer.sh using `transfer-sh-upload-agent-command'.
+  "Upload LOCAL-FILENAME to transfer.sh using `transfer-sh-upload-agent-command'.
 
 If no REMOTE-FILE is given, LOCAL-FILENAME is used."
   (let* ((filename-without-directory (file-name-nondirectory local-filename))
@@ -128,13 +130,13 @@ If no REMOTE-FILE is given, LOCAL-FILENAME is used."
 
 ;;;###autoload
 (defun transfer-sh-upload (async)
-  "Uploads either active region or complete buffer to transfer.sh.
+  "Upload either active region or complete buffer to transfer.sh.
 
 If a region is active, that region is exported to a file and then
-uploaded, otherwise the complete buffer is uploaded.  The remote
-file name is determined by the custom variables
-`transfer-sh-remote-prefix' and `transfer-sh-remote-suffix', and
-the buffer name."
+uploaded, otherwise the complete buffer is uploaded.
+
+This function uses `transfer-sh-upload-file' and
+`transfer-sh-upload-file-async'."
   (interactive "P")
   (let* ((remote-filename (concat transfer-sh-remote-prefix (buffer-name) transfer-sh-remote-suffix))
          (local-filename (if (use-region-p)

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -139,8 +139,8 @@ the buffer name."
                                (write-region (point-min) (point-max) transfer-sh-temp-file-location nil 0)
                                transfer-sh-temp-file-location)))))
     (if async
-        (transfer-sh-upload-file-async local-filename remote-filename)
-      (transfer-sh-upload-file local-filename remote-filename))))
+        (transfer-sh-upload-file-async local-filename)
+      (transfer-sh-upload-file local-filename))))
 
 ;;;###autoload
 (defun transfer-sh-upload-gpg (async)

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -104,8 +104,23 @@ If no REMOTE-FILENAME is given, the LOCAL-FILENAME is used."
                            (concat "curl --silent --upload-file "
                                    (shell-quote-argument local-filename)
                                    " " (shell-quote-argument (concat "https://transfer.sh/" remote-filename))))))
+(defun transfer-sh-run-upload-agent (local-filename  &optional remote-filename)
+  "Uploads LOCAL-FILENAME to transfer.sh using `transfer-sh-upload-agent-command'.
+
+If no REMOTE-FILE is given, LOCAL-FILENAME is used."
+  (let* ((filename-without-directory (file-name-nondirectory local-filename))
+	 (remote-filename (if remote-filename
+			      remote-filename
+			    filename-without-directory))
+	 (transfer-link (with-temp-buffer (apply 'call-process
+						 transfer-sh-upload-agent-command
+						 nil t nil
+						 (append transfer-sh-upload-agent-arguments
+							 (list local-filename
+							       (concat "https://transfer.sh/" remote-filename))))
+					  (buffer-string))))
     (kill-new transfer-link)
-    (message transfer-link)))
+    (message (concat "File '" filename-without-directory "' uploaded: " transfer-link))))
 
 ;;;###autoload
 (defun transfer-sh-upload (async)

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -54,6 +54,25 @@
   :type '(string)
   :group 'transfer-sh)
 
+(defcustom transfer-sh-upload-agent-command
+  (cond
+   ((executable-find "curl")
+    "curl")
+   ((executable-find "wget")
+    "wget"))
+  "Command used to upload files to transfer.sh"
+  :type '(string)
+  :group 'transfer-sh)
+
+(defcustom transfer-sh-upload-agent-arguments
+  (cond
+   ((executable-find "curl")
+    (list "--silent" "--upload-file"))
+   ((executable-find "wget")
+    (list "--method" "PUT" "--output-document" "-"  "--no-verbose" "--quiet" "--body-file")))
+  "Suffix arguments to `transfer-sh-upload-agent-command'"
+  :group 'transfer-sh)
+
 ;;;###autoload
 (defun transfer-sh-upload-file-async (local-filename &optional remote-filename)
   "Uploads file LOCAL-FILENAME to transfer.sh in background.

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -36,22 +36,22 @@
 
 (defcustom transfer-sh-temp-file-location "/tmp/transfer-sh.tmp"
   "The temporary file to use for uploading to transfer.sh."
-  :type '(string)
+  :type 'string
   :group 'transfer-sh)
 
 (defcustom transfer-sh-remote-prefix nil
   "A prefix added to each remote file name."
-  :type '(string)
+  :type 'string
   :group 'transfer-sh)
 
 (defcustom transfer-sh-remote-suffix nil
   "A suffix added to each remote file name."
-  :type '(string)
+  :type 'string
   :group 'transfer-sh)
 
 (defcustom transfer-sh-gpg-args "-ac -o-"
   "Arguments given to gpg when using transfer-sh-upload-gpg."
-  :type '(string)
+  :type 'string
   :group 'transfer-sh)
 
 (defcustom transfer-sh-upload-agent-command
@@ -61,7 +61,7 @@
    ((executable-find "wget")
     "wget"))
   "Command used to upload files to transfer.sh"
-  :type '(string)
+  :type 'string
   :group 'transfer-sh)
 
 (defcustom transfer-sh-upload-agent-arguments
@@ -71,6 +71,7 @@
    ((executable-find "wget")
     (list "--method" "PUT" "--output-document" "-"  "--no-verbose" "--quiet" "--body-file")))
   "Suffix arguments to `transfer-sh-upload-agent-command'"
+  :type '(repeat string)
   :group 'transfer-sh)
 
 ;;;###autoload

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -84,10 +84,11 @@ provided, query the user.
 This function uses `transfer-sh-run-upload-agent'."
   (interactive "ffile: ")
   (or remote-filename
-      (setq remote-filename (read-from-minibuffer
-                             (format "Remote filename (default %s): "
-                                     (file-name-nondirectory local-filename))
-                             (file-name-nondirectory local-filename))))
+      (setq remote-filename (url-encode-url
+                             (read-from-minibuffer
+                              (format "Remote filename (default %s): "
+                                      (file-name-nondirectory local-filename))
+                              (file-name-nondirectory local-filename)))))
   (async-start
    `(lambda ()
       ,(async-inject-variables "local-filename")
@@ -106,10 +107,11 @@ This function uses `transfer-sh-run-upload-agent'."
   (transfer-sh-run-upload-agent
    local-filename
    (or remote-filename
-       (read-from-minibuffer
-        (format "Remote filename (default %s): "
-                (file-name-nondirectory local-filename))
-        (file-name-nondirectory local-filename)))))
+       (url-encode-url
+        (read-from-minibuffer
+         (format "Remote filename (default %s): "
+                 (file-name-nondirectory local-filename))
+         (file-name-nondirectory local-filename))))))
 
 (defun transfer-sh-run-upload-agent (local-filename  &optional remote-filename)
   "Upload LOCAL-FILENAME to transfer.sh using `transfer-sh-upload-agent-command'.

--- a/transfer-sh.el
+++ b/transfer-sh.el
@@ -92,18 +92,16 @@ If no REMOTE-FILENAME is given, the LOCAL-FILENAME is used."
       (message transfer-link))))
 
 ;;;###autoload
-(defun transfer-sh-upload-file (local-filename &optional remote-filename)
+(defun transfer-sh-upload-file (local-filename)
   "Uploads file LOCAL-FILENAME to transfer.sh.
 
-If no REMOTE-FILENAME is given, the LOCAL-FILENAME is used."
+Read from minibuffer the remote file name visible in the transfer.sh link and run `transfer-sh-run-upload-agent'."
   (interactive "ffile: ")
-  (let*  ((remote-filename (if remote-filename
-                               remote-filename
-                             (file-name-nondirectory local-filename)))
-          (transfer-link (shell-command-to-string
-                           (concat "curl --silent --upload-file "
-                                   (shell-quote-argument local-filename)
-                                   " " (shell-quote-argument (concat "https://transfer.sh/" remote-filename))))))
+  (transfer-sh-run-upload-agent local-filename (read-from-minibuffer
+						(format "Remote filename (default %s): "
+							(file-name-nondirectory local-filename))
+						(file-name-nondirectory local-filename))))
+
 (defun transfer-sh-run-upload-agent (local-filename  &optional remote-filename)
   "Uploads LOCAL-FILENAME to transfer.sh using `transfer-sh-upload-agent-command'.
 


### PR DESCRIPTION
@SRoskamp,
Here is a list of the modifications I have done:
1) I did some slight modifications to the architecture allowing mroe flexibility to change the upload agent. The command and arguments are stored in two defcustoms. By default, it looks for `curl`, then `wget`. 
2) The call to the upload agent is now done in a single function `run-upload-agent`. The call is done through `call-process`.
3) The `remote-filename` is read from the mini-buffer, allowing the user to change it on-the-fly.
Any feedback is warmly welcome. 
Arnaud